### PR TITLE
Remove code comments when extracting variables.

### DIFF
--- a/PowerDocu.Common/AppParser.cs
+++ b/PowerDocu.Common/AppParser.cs
@@ -291,6 +291,10 @@ namespace PowerDocu.Common
 
         private void CheckForVariables(ControlEntity controlEntity, string input)
         {
+            if (hasCodeComments(input))
+            {
+                input = stripCodeComments(input);
+            }
             //Reference: https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/working-with-variables#types-of-variables
             string code = input.Replace("\n", "").Replace("\r", "");
             MatchCollection matches;
@@ -506,7 +510,7 @@ namespace PowerDocu.Common
             return extractedVariables;
         }
 
-        private int findClosingCharacter(string content, char open, char close)
+        public int findClosingCharacter(string content, char open, char close)
         {
             bool closingBracketFound = false;
             int currentClosingBracketIndex = content.IndexOf(close);
@@ -535,6 +539,18 @@ namespace PowerDocu.Common
             // case 1: no opening comment brackets (/*), thus we return false
             // case 2: there is an opening bracket. if there is no matching closing bracket, that means we are within a comment and need to return true
             return !(lastOpeningCommentBrackets == -1 || lastOpeningCommentBrackets < lastClosingCommentBrackets);
+        }
+
+        private bool hasCodeComments(string code)
+        {
+            var regex = @"(@(?:""[^""]*"")+|""(?:[^""\n\\]+|\\.)*""|'(?:[^'\n\\]+|\\.)*')|//.*|/\*(?s:.*?)\*/";
+            return Regex.Match(code, regex).Success;
+        }
+
+        private string stripCodeComments(string code)
+        {
+            var regex = @"(@(?:""[^""]*"")+|""(?:[^""\n\\]+|\\.)*""|'(?:[^'\n\\]+|\\.)*')|//.*|/\*(?s:.*?)\*/";
+            return Regex.Replace(code, regex, "$1");
         }
 
         private void parseAppDataSources(Stream appArchive)

--- a/PowerDocu.Common/AppParser.cs
+++ b/PowerDocu.Common/AppParser.cs
@@ -510,7 +510,7 @@ namespace PowerDocu.Common
             return extractedVariables;
         }
 
-        public int findClosingCharacter(string content, char open, char close)
+        private int findClosingCharacter(string content, char open, char close)
         {
             bool closingBracketFound = false;
             int currentClosingBracketIndex = content.IndexOf(close);


### PR DESCRIPTION
 This was causing an infinite loop in [extractContextVariableNames](https://github.com/modery/PowerDocu.Common/blob/f9043cf904a0563784ca70e9f1d4c7d974c0fe1c/PowerDocu.Common/AppParser.cs#LL442C42-L442C42) due to braces being inside comments and counts not matching.

I know you had a solution you were working on, but this worked for me when trying to get around this problem for an app I've been using for DevOps Pipeliness testing. So just throwing it in the pot if it gets you any closer to a solution :)

This relates to [findClosingCharacter never returns](https://github.com/modery/PowerDocu.Common/issues/2) and possibly [MSAPP file processing not completing](https://github.com/modery/PowerDocu/issues/84)