### PR TITLE
Feature/classic workflow documenter

### DIFF
--- a/PowerDocu.Common/CharsetHelper.cs
+++ b/PowerDocu.Common/CharsetHelper.cs
@@ -64,7 +64,11 @@ namespace PowerDocu.Common
                 sb.Append(isUnsafe ? '-' : normalized);
             }
 
-            return sb.ToString();
+            // Collapse consecutive dashes (e.g., "Name - Value" → "Name-Value" after space replacement)
+            string result = sb.ToString();
+            while (result.Contains("--"))
+                result = result.Replace("--", "-");
+            return result.Trim('-');
         }
     }
 }

--- a/PowerDocu.Common/ClassicWorkflowEntity.cs
+++ b/PowerDocu.Common/ClassicWorkflowEntity.cs
@@ -1,0 +1,292 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace PowerDocu.Common
+{
+    public class ClassicWorkflowEntity
+    {
+        public string ID;
+        public string Name;
+        public string UniqueName;
+        public string Description;
+        public string PrimaryEntity;
+        public int Category;
+        public int Mode;       // 0=Background, 1=Real-time
+        public int Scope;      // 1=User, 2=Business Unit, 3=Parent-Child BU, 4=Organization
+        public bool OnDemand;
+        public bool TriggerOnCreate;
+        public bool TriggerOnDelete;
+        public string TriggerOnUpdateAttributeList;
+        public int StateCode;
+        public int StatusCode;
+        public string IntroducedVersion;
+        public bool IsCustomizable;
+        public int Rank;       // 0=Calling User, 1=Owner
+        public string OwnerId;
+        public string XamlFileName;
+        public Dictionary<string, string> LocalizedNames = new Dictionary<string, string>();
+        public Dictionary<string, string> Descriptions = new Dictionary<string, string>();
+        public List<ClassicWorkflowStep> Steps = new List<ClassicWorkflowStep>();
+        public List<ClassicWorkflowTableReference> TableReferences = new List<ClassicWorkflowTableReference>();
+
+        public string GetDisplayName()
+        {
+            if (LocalizedNames.ContainsKey("1033"))
+                return LocalizedNames["1033"];
+            if (!string.IsNullOrEmpty(Name))
+                return Name;
+            return UniqueName ?? ID;
+        }
+
+        public string GetStateLabel()
+        {
+            return StateCode switch
+            {
+                0 => "Draft",
+                1 => "Active",
+                2 => "Suspended",
+                _ => "Unknown"
+            };
+        }
+
+        public string GetModeLabel()
+        {
+            return Mode switch
+            {
+                0 => "Background",
+                1 => "Real-time",
+                _ => "Unknown"
+            };
+        }
+
+        public string GetScopeLabel()
+        {
+            return Scope switch
+            {
+                1 => "User",
+                2 => "Business Unit",
+                3 => "Parent-Child Business Units",
+                4 => "Organization",
+                _ => "Unknown"
+            };
+        }
+
+        public string GetRunAsLabel()
+        {
+            return Rank switch
+            {
+                1 => "Owner",
+                _ => "Calling User"
+            };
+        }
+
+        public string GetCategoryLabel()
+        {
+            return Category switch
+            {
+                0 => "Workflow",
+                1 => "Dialog",
+                2 => "Business Rule",
+                3 => "Action",
+                4 => "Business Process Flow",
+                5 => "Modern Flow",
+                6 => "Desktop Flow",
+                _ => "Unknown (" + Category + ")"
+            };
+        }
+
+        public string GetTriggerDescription()
+        {
+            var parts = new List<string>();
+            if (OnDemand)
+                parts.Add("On-Demand");
+            if (TriggerOnCreate)
+                parts.Add("Record Created");
+            if (TriggerOnDelete)
+                parts.Add("Record Deleted");
+            if (!string.IsNullOrEmpty(TriggerOnUpdateAttributeList))
+                parts.Add("Record Updated (" + TriggerOnUpdateAttributeList + ")");
+
+            return parts.Count > 0 ? string.Join(", ", parts) : "None";
+        }
+    }
+
+    public enum ClassicWorkflowStepType
+    {
+        CheckCondition,
+        ConditionBranch,
+        CreateRecord,
+        UpdateRecord,
+        SendEmail,
+        Assign,
+        ChangeStatus,
+        Stop,
+        ChildWorkflow,
+        Wait,
+        SetVisibility,
+        SetDisplayMode,
+        SetFieldRequired,
+        SetAttributeValue,
+        SetDefaultValue,
+        SetMessage,
+        Custom
+    }
+
+    public class ClassicWorkflowStep
+    {
+        public string StepId;
+        public string Name;
+        public ClassicWorkflowStepType StepType;
+        public string TargetEntity;
+        public string CustomActivityName;   // For Custom step type: short class name (e.g., "ToFormattedString")
+        public string CustomActivityClass;  // Full class name (e.g., "MARCY.Activities.DateTimes.ToFormattedString")
+        public string CustomActivityAssembly; // Assembly name (e.g., "MARCY.Activities, Version=1.0.0.0, PublicKeyToken=2fb77a038cccb985")
+        public string CustomActivityFriendlyName; // Registered friendly name
+        public string CustomActivityDescription;  // Registered description
+        public string CustomActivityGroupName;    // Registered group name
+        public string ConditionDescription; // Simple flat text fallback
+        public ConditionExpression ConditionTree; // Structured condition tree for rich rendering
+        public string StepDescription;  // User-provided step description from stepLabelDescription
+        public List<ClassicWorkflowFieldAssignment> Fields = new List<ClassicWorkflowFieldAssignment>();
+        public List<ClassicWorkflowStep> ChildSteps = new List<ClassicWorkflowStep>();
+        public int NestingLevel;
+
+        public string GetStepTypeLabel()
+        {
+            return StepType switch
+            {
+                ClassicWorkflowStepType.CheckCondition => "Check Condition",
+                ClassicWorkflowStepType.ConditionBranch => "Condition Branch",
+                ClassicWorkflowStepType.CreateRecord => "Create Record",
+                ClassicWorkflowStepType.UpdateRecord => "Update Record",
+                ClassicWorkflowStepType.SendEmail => "Send Email",
+                ClassicWorkflowStepType.Assign => "Assign",
+                ClassicWorkflowStepType.ChangeStatus => "Change Status",
+                ClassicWorkflowStepType.Stop => "Stop",
+                ClassicWorkflowStepType.ChildWorkflow => "Child Workflow",
+                ClassicWorkflowStepType.Wait => "Wait",
+                ClassicWorkflowStepType.SetVisibility => "Set Visibility",
+                ClassicWorkflowStepType.SetDisplayMode => "Set Display Mode",
+                ClassicWorkflowStepType.SetFieldRequired => "Set Field Required",
+                ClassicWorkflowStepType.SetAttributeValue => "Set Attribute Value",
+                ClassicWorkflowStepType.SetDefaultValue => "Set Default Value",
+                ClassicWorkflowStepType.SetMessage => "Set Message",
+                ClassicWorkflowStepType.Custom => !string.IsNullOrEmpty(CustomActivityName) ? CustomActivityName : "Custom",
+                _ => "Unknown"
+            };
+        }
+    }
+
+    public class ClassicWorkflowFieldAssignment
+    {
+        public string FieldName;
+        public string Value;
+        public string SourceType;   // Static, Dynamic, Lookup
+    }
+
+    public enum ClassicWorkflowReferenceType
+    {
+        Trigger,
+        Create,
+        Update,
+        Read,
+        Assign,
+        ChangeStatus,
+        ChildWorkflow,
+        SendEmail
+    }
+
+    public class ClassicWorkflowTableReference
+    {
+        public string TableLogicalName;
+        public ClassicWorkflowReferenceType ReferenceType;
+    }
+
+    /// <summary>
+    /// Tree structure representing a workflow condition expression.
+    /// Leaf nodes are comparisons (field operator value).
+    /// Branch nodes are AND/OR groups containing child expressions.
+    /// </summary>
+    public class ConditionExpression
+    {
+        /// <summary>Logical grouping operator for branch nodes (AND/OR). Null for leaf nodes.</summary>
+        public string LogicalOperator; // "AND", "OR", or null for leaf
+
+        /// <summary>For leaf: the entity/field being evaluated (e.g., "msf_changerequests.msf_issmdecision")</summary>
+        public string Field;
+
+        /// <summary>For leaf: the comparison operator (e.g., "Equals", "Contains Data")</summary>
+        public string Operator;
+
+        /// <summary>For leaf: the comparison value (e.g., "100000002", or null for unary ops like NotNull)</summary>
+        public string Value;
+
+        /// <summary>Child expressions for AND/OR groups</summary>
+        public List<ConditionExpression> Children = new List<ConditionExpression>();
+
+        public bool IsLeaf => string.IsNullOrEmpty(LogicalOperator);
+        public bool IsGroup => !IsLeaf;
+
+        /// <summary>Renders the condition tree as a flat human-readable string (fallback)</summary>
+        public string ToFlatString()
+        {
+            if (IsLeaf)
+            {
+                return string.IsNullOrEmpty(Value)
+                    ? $"{Field} {Operator}"
+                    : $"{Field} {Operator} {Value}";
+            }
+
+            var parts = new List<string>();
+            foreach (var child in Children)
+            {
+                string childStr = child.IsGroup && child.Children.Count > 1
+                    ? "(" + child.ToFlatString() + ")"
+                    : child.ToFlatString();
+                parts.Add(childStr);
+            }
+            return string.Join($" {LogicalOperator} ", parts);
+        }
+
+        /// <summary>
+        /// Renders the condition tree as indented lines for display.
+        /// Each line is a tuple of (indentLevel, text).
+        /// </summary>
+        public List<(int indent, string text)> ToIndentedLines(int baseIndent = 0)
+        {
+            var lines = new List<(int indent, string text)>();
+
+            if (IsLeaf)
+            {
+                string line = string.IsNullOrEmpty(Value)
+                    ? $"{Field} {Operator}"
+                    : $"{Field} {Operator} {Value}";
+                lines.Add((baseIndent, line));
+            }
+            else
+            {
+                for (int i = 0; i < Children.Count; i++)
+                {
+                    var child = Children[i];
+                    if (child.IsGroup)
+                    {
+                        // Group header
+                        lines.Add((baseIndent, $"Group ({child.LogicalOperator}):"));
+                        lines.AddRange(child.ToIndentedLines(baseIndent + 1));
+                    }
+                    else
+                    {
+                        lines.AddRange(child.ToIndentedLines(baseIndent));
+                    }
+                    // Add the operator between children (not after the last)
+                    if (i < Children.Count - 1)
+                    {
+                        lines.Add((baseIndent, LogicalOperator));
+                    }
+                }
+            }
+
+            return lines;
+        }
+    }
+}

--- a/PowerDocu.Common/ClassicWorkflowXamlParser.cs
+++ b/PowerDocu.Common/ClassicWorkflowXamlParser.cs
@@ -1,0 +1,1434 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace PowerDocu.Common
+{
+    /// <summary>
+    /// Parses Classic Workflow XAML definitions into ClassicWorkflowEntity step trees.
+    /// 
+    /// Classic Workflow XAML structure:
+    /// - Root: &lt;Activity&gt; → &lt;mxswa:Workflow&gt;
+    /// - Direct mxswa: elements: UpdateEntity, CreateEntity, SendEmail, SetState, AssignEntity,
+    ///   GetEntityProperty, SetEntityProperty, Postpone, RetrieveEntity
+    /// - ActivityReference wrappers: ConditionSequence, ConditionBranch, Composite,
+    ///   EvaluateCondition, EvaluateExpression, custom activities
+    /// - Client activities (mcwc:): SetDisplayMode, SetVisibility, SetFieldRequiredLevel,
+    ///   SetAttributeValue, SetDefaultValue, SetMessage
+    /// - Bare elements: TerminateWorkflow, Sequence, Assign, If
+    /// </summary>
+    public static class ClassicWorkflowXamlParser
+    {
+        /// <summary>
+        /// Maps variable names to human-readable descriptions of their source.
+        /// Built by scanning GetEntityProperty and EvaluateExpression (CreateCrmType) nodes
+        /// before parsing steps, so that dynamic references can be resolved.
+        /// </summary>
+        private static Dictionary<string, string> _variableMap;
+
+        /// <summary>
+        /// Maps condition result variable names to structured ConditionExpression trees.
+        /// Built by scanning EvaluateCondition and EvaluateLogicalCondition nodes.
+        /// </summary>
+        private static Dictionary<string, ConditionExpression> _conditionTreeMap;
+
+        public static void ParseClassicWorkflowXaml(ClassicWorkflowEntity workflow, string xamlContent)
+        {
+            if (string.IsNullOrEmpty(xamlContent)) return;
+            XmlDocument doc = new XmlDocument { XmlResolver = null };
+            try
+            {
+                doc.LoadXml(xamlContent);
+            }
+            catch
+            {
+                return;
+            }
+
+            // Find the mxswa:Workflow element
+            XmlNode workflowNode = FindWorkflowNode(doc.DocumentElement);
+            if (workflowNode == null)
+                workflowNode = doc.DocumentElement; // fallback to root
+
+            // Phase 1: Build variable resolution map from GetEntityProperty and CreateCrmType
+            _variableMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _conditionTreeMap = new Dictionary<string, ConditionExpression>(StringComparer.OrdinalIgnoreCase);
+            BuildVariableMap(workflowNode);
+
+            // Phase 2: Parse steps
+            ParseStepsRecursive(workflowNode, workflow.Steps, 0);
+            BuildTableReferences(workflow);
+
+            _variableMap = null;
+            _conditionTreeMap = null;
+        }
+
+        private static XmlNode FindWorkflowNode(XmlNode root)
+        {
+            if (root == null) return null;
+            foreach (XmlNode child in root.ChildNodes)
+            {
+                if (child.LocalName == "Workflow")
+                    return child;
+                XmlNode found = FindWorkflowNode(child);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Scans the entire XAML tree to build a variable-to-description map.
+        /// Traces: GetEntityProperty → variable (e.g., "Entity.Attribute")
+        ///         CreateCrmType → variable (e.g., literal value "100000002")
+        ///         SelectFirstNonNull/ConvertCrmXrmTypes → propagate source
+        /// </summary>
+        private static void BuildVariableMap(XmlNode node)
+        {
+            if (node == null) return;
+
+            // GetEntityProperty: maps Value variable to "{EntityName}.{Attribute}"
+            if (node.LocalName == "GetEntityProperty")
+            {
+                string attr = node.Attributes?["Attribute"]?.Value;
+                string entityName = node.Attributes?["EntityName"]?.Value;
+                string valueVar = node.Attributes?["Value"]?.Value;
+                if (!string.IsNullOrEmpty(valueVar) && !string.IsNullOrEmpty(attr))
+                {
+                    string varName = valueVar.Trim('[', ']');
+                    string entityPart = !string.IsNullOrEmpty(entityName) ? entityName + "." : "";
+
+                    // Check if the Entity references a related entity
+                    string entityRef = node.Attributes?["Entity"]?.Value ?? "";
+                    if (entityRef.Contains("related_"))
+                    {
+                        // InputEntities("related_msf_assigned#msf_person") → "msf_person (Related)"
+                        var match = System.Text.RegularExpressions.Regex.Match(entityRef, @"related_[^#]*#(\w+)");
+                        if (match.Success)
+                            entityPart = match.Groups[1].Value + " (Related).";
+                    }
+
+                    _variableMap[varName] = "{" + entityPart + attr + "}";
+                }
+            }
+
+            // EvaluateExpression with CreateCrmType: maps Result variable to literal value
+            if (node.LocalName == "ActivityReference")
+            {
+                string aqn = node.Attributes?["AssemblyQualifiedName"]?.Value;
+                if (aqn != null && aqn.Contains("EvaluateExpression"))
+                {
+                    string op = GetArgumentValue(node, "ExpressionOperator");
+                    string resultVar = GetArgumentValue(node, "Result", isOutput: true);
+
+                    if (op == "CreateCrmType" && !string.IsNullOrEmpty(resultVar))
+                    {
+                        // Parameters: [New Object() { WorkflowPropertyType.String, "value", "String" }]
+                        string paramRaw = GetArgumentValue(node, "Parameters");
+                        string literal = ExtractLiteralFromCreateCrmType(paramRaw);
+                        if (!string.IsNullOrEmpty(literal))
+                            _variableMap[resultVar] = "\"" + literal + "\"";
+                    }
+                    else if (op == "SelectFirstNonNull" && !string.IsNullOrEmpty(resultVar))
+                    {
+                        // Propagate source: Parameters contains the source variable
+                        string paramRaw = GetArgumentValue(node, "Parameters");
+                        string sourceVar = ExtractVariableFromParams(paramRaw);
+                        if (!string.IsNullOrEmpty(sourceVar) && _variableMap.ContainsKey(sourceVar))
+                            _variableMap[resultVar] = _variableMap[sourceVar];
+                    }
+                    else if (op == "Add" && !string.IsNullOrEmpty(resultVar))
+                    {
+                        // String concatenation: resolve each part
+                        string paramRaw = GetArgumentValue(node, "Parameters");
+                        string resolved = ResolveAddExpression(paramRaw);
+                        if (!string.IsNullOrEmpty(resolved))
+                            _variableMap[resultVar] = resolved;
+                    }
+                    else if (!string.IsNullOrEmpty(op) && !string.IsNullOrEmpty(resultVar))
+                    {
+                        // Handle other expression operators as system values
+                        // RetrieveCurrentTime → "Execution Time"
+                        // RetrieveActivityCount → "Activity Count"
+                        string systemLabel = op switch
+                        {
+                            "RetrieveCurrentTime" => "{Process.Execution Time}",
+                            "RetrieveActivityCount" => "{Process.Activity Count}",
+                            "RetrieveUserId" => "{Process.Initiating User}",
+                            _ => null
+                        };
+                        if (!string.IsNullOrEmpty(systemLabel))
+                            _variableMap[resultVar] = systemLabel;
+                    }
+                }
+                else if (aqn != null && aqn.Contains("ConvertCrmXrmTypes"))
+                {
+                    // Propagate: Value → Result
+                    string valueVar = GetArgumentValue(node, "Value");
+                    string resultVar = GetArgumentValue(node, "Result", isOutput: true);
+                    if (!string.IsNullOrEmpty(valueVar) && !string.IsNullOrEmpty(resultVar))
+                    {
+                        if (_variableMap.ContainsKey(valueVar))
+                            _variableMap[resultVar] = _variableMap[valueVar];
+                    }
+                    // Also map the _converted variant
+                    if (!string.IsNullOrEmpty(resultVar) && !_variableMap.ContainsKey(resultVar) &&
+                        !string.IsNullOrEmpty(valueVar) && _variableMap.ContainsKey(valueVar))
+                        _variableMap[resultVar] = _variableMap[valueVar];
+                }
+                else if (aqn != null && aqn.Contains("EvaluateCondition"))
+                {
+                    // Single condition: Operand <ConditionOperator> Parameters → Result
+                    string condOp = GetArgumentValue(node, "ConditionOperator");
+                    string operandVar = GetArgumentValue(node, "Operand");
+                    string paramRaw = GetArgumentValue(node, "Parameters");
+                    string resultVar = GetArgumentValue(node, "Result", isOutput: true);
+
+                    if (!string.IsNullOrEmpty(resultVar) && !string.IsNullOrEmpty(condOp))
+                    {
+                        string operandDesc = ResolveVariableRef(operandVar);
+                        string paramDesc = "";
+                        if (!string.IsNullOrEmpty(paramRaw))
+                        {
+                            // Handle multiple parameters (e.g., In operator with multiple values)
+                            var allParamVars = ExtractAllVariablesFromParams(paramRaw);
+                            if (allParamVars.Count > 0)
+                            {
+                                var resolvedParams = new List<string>();
+                                foreach (string pv in allParamVars)
+                                    resolvedParams.Add(ResolveVariableRef(pv));
+                                paramDesc = string.Join(", ", resolvedParams);
+                            }
+                        }
+
+                        string humanOp = HumanReadableOperator(condOp);
+
+                        // Build leaf condition expression
+                        var leaf = new ConditionExpression
+                        {
+                            Field = operandDesc,
+                            Operator = humanOp,
+                            Value = string.IsNullOrEmpty(paramDesc) ? null : paramDesc
+                        };
+                        _conditionTreeMap[resultVar] = leaf;
+                    }
+                }
+                else if (aqn != null && aqn.Contains("EvaluateLogicalCondition"))
+                {
+                    // Logical combiner: LeftOperand <LogicalOperator> RightOperand → Result
+                    string logicalOp = GetArgumentValue(node, "LogicalOperator");
+                    string leftVar = GetArgumentValue(node, "LeftOperand");
+                    string rightVar = GetArgumentValue(node, "RightOperand");
+                    string resultVar = GetArgumentValue(node, "Result", isOutput: true);
+
+                    if (!string.IsNullOrEmpty(resultVar))
+                    {
+                        string op = logicalOp?.ToUpperInvariant() ?? "AND";
+                        ConditionExpression leftTree = _conditionTreeMap.ContainsKey(leftVar) ? _conditionTreeMap[leftVar] : null;
+                        ConditionExpression rightTree = _conditionTreeMap.ContainsKey(rightVar) ? _conditionTreeMap[rightVar] : null;
+
+                        // Flatten same-operator chains in both directions
+                        bool leftIsSameGroup = leftTree != null && leftTree.IsGroup && leftTree.LogicalOperator == op;
+                        bool rightIsSameGroup = rightTree != null && rightTree.IsGroup && rightTree.LogicalOperator == op;
+
+                        if (leftIsSameGroup && rightIsSameGroup)
+                        {
+                            // Both are same-op groups: merge right's children into left
+                            leftTree.Children.AddRange(rightTree.Children);
+                            _conditionTreeMap[resultVar] = leftTree;
+                        }
+                        else if (leftIsSameGroup)
+                        {
+                            if (rightTree != null)
+                                leftTree.Children.Add(rightTree);
+                            _conditionTreeMap[resultVar] = leftTree;
+                        }
+                        else if (rightIsSameGroup)
+                        {
+                            // Right is same-op group: prepend left into it
+                            if (leftTree != null)
+                                rightTree.Children.Insert(0, leftTree);
+                            _conditionTreeMap[resultVar] = rightTree;
+                        }
+                        else
+                        {
+                            var group = new ConditionExpression { LogicalOperator = op };
+                            if (leftTree != null) group.Children.Add(leftTree);
+                            if (rightTree != null) group.Children.Add(rightTree);
+                            _conditionTreeMap[resultVar] = group;
+                        }
+                    }
+                }
+            }
+
+            foreach (XmlNode child in node.ChildNodes)
+                BuildVariableMap(child);
+        }
+
+        /// <summary>Resolves a variable name to its human-readable source from the variable map.</summary>
+        private static string ResolveVariableRef(string varName)
+        {
+            if (string.IsNullOrEmpty(varName)) return "(unknown)";
+            if (_variableMap != null && _variableMap.TryGetValue(varName, out string desc))
+                return desc;
+            return varName;
+        }
+
+        private static string HumanReadableOperator(string conditionOperator)
+        {
+            return conditionOperator switch
+            {
+                "Equal" => "Equals",
+                "NotEqual" => "Does Not Equal",
+                "GreaterThan" => ">",
+                "LessThan" => "<",
+                "GreaterEqual" or "GreaterOrEqual" => ">=",
+                "LessEqual" or "LessOrEqual" => "<=",
+                "NotNull" => "Contains Data",
+                "Null" => "Does Not Contain Data",
+                "In" => "Is In",
+                "NotIn" => "Is Not In",
+                "Like" => "Like",
+                "NotLike" => "Not Like",
+                "BeginsWith" => "Begins With",
+                "EndsWith" => "Ends With",
+                "Contains" => "Contains",
+                "DoesNotContain" => "Does Not Contain",
+                "DoesNotBeginWith" => "Does Not Begin With",
+                "DoesNotEndWith" => "Does Not End With",
+                _ => conditionOperator
+            };
+        }
+
+        private static string GetArgumentValue(XmlNode activityRef, string key, bool isOutput = false)
+        {
+            foreach (XmlNode child in activityRef.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference.Arguments")
+                {
+                    foreach (XmlNode arg in child.ChildNodes)
+                    {
+                        string argKey = arg.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(arg, "Key");
+                        if (argKey == key)
+                        {
+                            string raw = arg.InnerText?.Trim() ?? "";
+                            return raw.Trim('[', ']');
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static string ExtractLiteralFromCreateCrmType(string paramRaw)
+        {
+            // Pattern: New Object() { WorkflowPropertyType.String, "actualValue", "String" }
+            // or: New Object() { WorkflowPropertyType.OptionSetValue, "100000002", "Picklist" }
+            if (string.IsNullOrEmpty(paramRaw)) return null;
+            var match = System.Text.RegularExpressions.Regex.Match(paramRaw,
+                @"WorkflowPropertyType\.\w+,\s*""([^""]*)""\s*(?:,\s*""[^""]*"")?");
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        private static string ExtractVariableFromParams(string paramRaw)
+        {
+            // Pattern: New Object() { VariableName }
+            if (string.IsNullOrEmpty(paramRaw)) return null;
+            var match = System.Text.RegularExpressions.Regex.Match(paramRaw, @"\{\s*(\w+)\s*\}");
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        private static List<string> ExtractAllVariablesFromParams(string paramRaw)
+        {
+            // Pattern: New Object() { Var1, Var2, Var3 }
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(paramRaw)) return result;
+            var match = System.Text.RegularExpressions.Regex.Match(paramRaw, @"\{(.+)\}");
+            if (!match.Success) return result;
+            string[] parts = match.Groups[1].Value.Split(',');
+            foreach (string part in parts)
+            {
+                string trimmed = part.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    result.Add(trimmed);
+            }
+            return result;
+        }
+
+        private static string ResolveAddExpression(string paramRaw)
+        {
+            // Pattern: New Object() { Var1, Var2, Var3 }
+            if (string.IsNullOrEmpty(paramRaw)) return null;
+            var match = System.Text.RegularExpressions.Regex.Match(paramRaw, @"\{(.+)\}");
+            if (!match.Success) return null;
+
+            string[] parts = match.Groups[1].Value.Split(',');
+            var resolved = new List<string>();
+            foreach (string part in parts)
+            {
+                string varName = part.Trim();
+                if (_variableMap.ContainsKey(varName))
+                    resolved.Add(_variableMap[varName]);
+                else
+                    resolved.Add("{" + varName + "}");
+            }
+            return string.Join(" + ", resolved);
+        }
+
+        private static void ParseStepsRecursive(XmlNode parent, List<ClassicWorkflowStep> steps, int nestingLevel)
+        {
+            if (parent == null) return;
+
+            foreach (XmlNode child in parent.ChildNodes)
+            {
+                ClassicWorkflowStep step = TryParseAsStep(child, nestingLevel);
+                if (step != null)
+                {
+                    // Extract step description from parent Sequence's Variables
+                    if (string.IsNullOrEmpty(step.StepDescription))
+                        step.StepDescription = ExtractStepDescription(child);
+                    steps.Add(step);
+                }
+                else if (!IsSkippableStructuralNode(child))
+                {
+                    // Recurse into non-step structural elements (Properties, Activities collections, etc.)
+                    ParseStepsRecursive(child, steps, nestingLevel);
+                }
+            }
+        }
+
+        private static ClassicWorkflowStep TryParseAsStep(XmlNode node, int nestingLevel)
+        {
+            if (node == null) return null;
+            string localName = node.LocalName;
+
+            // ── Direct mxswa: elements ──
+            switch (localName)
+            {
+                case "UpdateEntity":
+                    return ParseDirectElement(node, ClassicWorkflowStepType.UpdateRecord, nestingLevel);
+                case "CreateEntity":
+                    return ParseDirectElement(node, ClassicWorkflowStepType.CreateRecord, nestingLevel);
+                case "SendEmail":
+                    return ParseSendEmail(node, nestingLevel);
+                case "SetState":
+                    return ParseSetState(node, nestingLevel);
+                case "AssignEntity":
+                    return ParseAssignEntity(node, nestingLevel);
+                case "Postpone":
+                    return ParsePostpone(node, nestingLevel);
+            }
+
+            // ── TerminateWorkflow (bare element) ──
+            if (localName == "TerminateWorkflow")
+            {
+                string userDesc = ExtractDisplayNameDescription(node);
+                string friendlyName = "Stop Workflow";
+                if (!string.IsNullOrEmpty(userDesc) && !userDesc.StartsWith("StopWorkflowStep"))
+                    friendlyName = userDesc;
+
+                var step = new ClassicWorkflowStep
+                {
+                    StepType = ClassicWorkflowStepType.Stop,
+                    Name = friendlyName,
+                    StepId = ExtractStepIdFromDisplayName(node),
+                    NestingLevel = nestingLevel
+                };
+
+                // Extract status (Succeeded/Canceled) from Exception attribute
+                string exception = node.Attributes?["Exception"]?.Value ?? "";
+                if (exception.Contains("Succeeded"))
+                    step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Status", Value = "Succeeded", SourceType = "Static" });
+                else if (exception.Contains("Canceled") || exception.Contains("Failed"))
+                    step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Status", Value = "Canceled", SourceType = "Static" });
+
+                // Extract reason/message
+                string reason = node.Attributes?["Reason"]?.Value ?? "";
+                string resolvedReason = CleanDynamicExpression(reason);
+                if (!string.IsNullOrEmpty(resolvedReason) && resolvedReason != "(Dynamic)")
+                    step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Message", Value = resolvedReason, SourceType = "Static" });
+
+                return step;
+            }
+
+            // ── InvokeSdkMessageActivity (Action step) ──
+            if (localName == "InvokeSdkMessageActivity")
+            {
+                string userDesc = ExtractDisplayNameDescription(node);
+                string friendlyName = "Run Action";
+                if (!string.IsNullOrEmpty(userDesc) && !userDesc.StartsWith("InvokeSdkMessageStep"))
+                    friendlyName = userDesc;
+
+                var step = new ClassicWorkflowStep
+                {
+                    StepType = ClassicWorkflowStepType.ChildWorkflow,
+                    Name = friendlyName,
+                    StepId = ExtractStepIdFromDisplayName(node),
+                    NestingLevel = nestingLevel
+                };
+
+                string sdkMessageName = node.Attributes?["SdkMessageName"]?.Value;
+                string sdkEntityName = node.Attributes?["SdkMessageEntityName"]?.Value;
+
+                if (!string.IsNullOrEmpty(sdkMessageName))
+                    step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Action Name", Value = sdkMessageName, SourceType = "Static" });
+                if (!string.IsNullOrEmpty(sdkEntityName) && sdkEntityName != "none")
+                    step.TargetEntity = sdkEntityName;
+                else if (sdkEntityName == "none")
+                    step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Entity", Value = "Global (none)", SourceType = "Static" });
+
+                // Extract arguments
+                foreach (XmlNode child in node.ChildNodes)
+                {
+                    if (child.LocalName == "InvokeSdkMessageActivity.Arguments")
+                    {
+                        foreach (XmlNode arg in child.ChildNodes)
+                        {
+                            if (arg.LocalName == "InArgument" || arg.LocalName.StartsWith("InArgument"))
+                            {
+                                string key = arg.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(arg, "Key");
+                                if (!string.IsNullOrEmpty(key) && key != "Target")
+                                {
+                                    string rawValue = arg.InnerText?.Trim() ?? "";
+                                    step.Fields.Add(new ClassicWorkflowFieldAssignment
+                                    {
+                                        FieldName = key,
+                                        Value = CleanDynamicExpression(rawValue),
+                                        SourceType = rawValue.StartsWith("[") ? "Dynamic" : "Static"
+                                    });
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+
+                return step;
+            }
+
+            // ── Client activities (mcwc:) ──
+            switch (localName)
+            {
+                case "SetDisplayMode":
+                    return ParseClientActivity(node, ClassicWorkflowStepType.SetDisplayMode, nestingLevel);
+                case "SetVisibility":
+                    return ParseClientActivity(node, ClassicWorkflowStepType.SetVisibility, nestingLevel);
+                case "SetFieldRequiredLevel":
+                    return ParseClientActivity(node, ClassicWorkflowStepType.SetFieldRequired, nestingLevel);
+                case "SetAttributeValue":
+                    return ParseClientActivity(node, ClassicWorkflowStepType.SetAttributeValue, nestingLevel);
+                case "SetDefaultValue":
+                    return ParseClientActivity(node, ClassicWorkflowStepType.SetDefaultValue, nestingLevel);
+                case "SetMessage":
+                    return ParseClientActivity(node, ClassicWorkflowStepType.SetMessage, nestingLevel);
+            }
+
+            // ── ActivityReference elements ──
+            if (localName == "ActivityReference")
+            {
+                string aqn = node.Attributes?["AssemblyQualifiedName"]?.Value;
+                if (string.IsNullOrEmpty(aqn)) return null;
+
+                string typeName = ExtractTypeName(aqn);
+
+                switch (typeName)
+                {
+                    case "ConditionSequence":
+                        return ParseConditionSequence(node, nestingLevel);
+                    case "ConditionBranch":
+                        return ParseConditionBranch(node, nestingLevel);
+                    case "Composite":
+                        return ParseComposite(node, nestingLevel);
+
+                    // Evaluation helpers — skip as standalone steps, they're internal plumbing
+                    case "EvaluateCondition":
+                    case "EvaluateExpression":
+                    case "EvaluateLogicalCondition":
+                    case "ConvertCrmXrmTypes":
+                        return null;
+
+                    // BPF-related elements in workflow context — skip
+                    case "EntityComposite":
+                    case "StageComposite":
+                    case "StepComposite":
+                    case "StageRelationshipCollectionComposite":
+                        return null;
+
+                    default:
+                        // Custom activity (e.g., MARCY.Activities.*)
+                        if (!aqn.StartsWith("Microsoft.Crm.Workflow") &&
+                            !aqn.StartsWith("Microsoft.Xrm.Sdk"))
+                        {
+                            return ParseCustomActivity(node, aqn, nestingLevel);
+                        }
+                        return null;
+                }
+            }
+
+            return null;
+        }
+
+        // ── Parsing methods for each step type ──
+
+        private static ClassicWorkflowStep ParseDirectElement(XmlNode node, ClassicWorkflowStepType stepType, int nestingLevel)
+        {
+            string entityName = node.Attributes?["EntityName"]?.Value;
+            string friendlyName = stepType switch
+            {
+                ClassicWorkflowStepType.UpdateRecord => "Update " + (entityName ?? "Record"),
+                ClassicWorkflowStepType.CreateRecord => "Create " + (entityName ?? "Record"),
+                _ => ExtractDisplayNameDescription(node) ?? stepType.ToString()
+            };
+            // Use user-provided description from DisplayName if it has one (e.g., "UpdateStep5: My Description")
+            string userDesc = ExtractDisplayNameDescription(node);
+            if (!string.IsNullOrEmpty(userDesc) && !userDesc.StartsWith("UpdateStep") && !userDesc.StartsWith("CreateStep"))
+                friendlyName = userDesc;
+
+            var step = new ClassicWorkflowStep
+            {
+                StepType = stepType,
+                Name = friendlyName,
+                StepId = ExtractStepIdFromDisplayName(node),
+                TargetEntity = entityName,
+                NestingLevel = nestingLevel
+            };
+
+            // For UpdateEntity/CreateEntity — collect SetEntityProperty children as field assignments
+            if (stepType == ClassicWorkflowStepType.UpdateRecord || stepType == ClassicWorkflowStepType.CreateRecord)
+            {
+                CollectFieldAssignmentsFromSiblings(node, step.Fields);
+            }
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParseSetState(XmlNode node, int nestingLevel)
+        {
+            string entityName = node.Attributes?["EntityName"]?.Value;
+            string userDesc = ExtractDisplayNameDescription(node);
+            string friendlyName = "Change Status";
+            if (!string.IsNullOrEmpty(userDesc) && !userDesc.StartsWith("SetStateStep"))
+                friendlyName = userDesc;
+            else if (!string.IsNullOrEmpty(entityName))
+                friendlyName = "Change Status: " + entityName;
+
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.ChangeStatus,
+                Name = friendlyName,
+                StepId = ExtractStepIdFromDisplayName(node),
+                TargetEntity = entityName,
+                NestingLevel = nestingLevel
+            };
+
+            // Extract state/status values from child elements
+            string stateVal = ExtractOptionSetValue(node, "State");
+            string statusVal = ExtractOptionSetValue(node, "Status");
+            if (!string.IsNullOrEmpty(stateVal))
+                step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "State", Value = stateVal, SourceType = "Static" });
+            if (!string.IsNullOrEmpty(statusVal))
+                step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Status", Value = statusVal, SourceType = "Static" });
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParsePostpone(XmlNode node, int nestingLevel)
+        {
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.Wait,
+                Name = ExtractDisplayNameDescription(node) ?? "Wait",
+                StepId = ExtractStepIdFromDisplayName(node),
+                NestingLevel = nestingLevel
+            };
+
+            // Extract wait details
+            string blockExecution = node.Attributes?["BlockExecution"]?.Value;
+            if (!string.IsNullOrEmpty(blockExecution))
+                step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Block Execution", Value = blockExecution, SourceType = "Static" });
+
+            string postponeUntil = node.Attributes?["PostponeUntil"]?.Value;
+            if (!string.IsNullOrEmpty(postponeUntil))
+                step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Wait Until", Value = CleanDynamicExpression(postponeUntil), SourceType = postponeUntil.StartsWith("[") ? "Dynamic" : "Static" });
+
+            return step;
+        }
+
+        // Friendly label map for email entity fields
+        private static readonly Dictionary<string, string> EmailFieldLabels = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "from", "From" },
+            { "to", "To" },
+            { "cc", "CC" },
+            { "bcc", "BCC" },
+            { "subject", "Subject" },
+            { "description", "Body" },
+            { "regardingobjectid", "Regarding" },
+            { "prioritycode", "Priority" },
+            { "deliveryprioritycode", "Delivery Priority" },
+            { "directioncode", "Direction" },
+            { "transactioncurrencyid", "Currency" }
+        };
+
+        // System/internal email fields to skip in documentation
+        private static readonly HashSet<string> EmailFieldsToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "correlatedsubjectchanged",
+            "followemailuserpreference",
+            "isduplicatesenderunresolved",
+            "notifications"
+        };
+
+        private static ClassicWorkflowStep ParseSendEmail(XmlNode node, int nestingLevel)
+        {
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.SendEmail,
+                Name = "Create Message",
+                StepId = ExtractStepIdFromDisplayName(node),
+                TargetEntity = "email",
+                NestingLevel = nestingLevel
+            };
+
+            // Collect email field assignments from SetEntityProperty siblings
+            CollectFieldAssignmentsFromSiblings(node, step.Fields);
+
+            // Post-process: apply friendly labels and filter out internal fields
+            var filtered = new List<ClassicWorkflowFieldAssignment>();
+            foreach (var field in step.Fields)
+            {
+                if (EmailFieldsToSkip.Contains(field.FieldName))
+                    continue;
+
+                if (EmailFieldLabels.TryGetValue(field.FieldName, out string friendlyName))
+                    field.FieldName = friendlyName;
+
+                filtered.Add(field);
+            }
+            step.Fields.Clear();
+            step.Fields.AddRange(filtered);
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParseAssignEntity(XmlNode node, int nestingLevel)
+        {
+            string entityName = node.Attributes?["EntityName"]?.Value;
+            string userDesc = ExtractDisplayNameDescription(node);
+            string friendlyName = "Assign";
+            if (!string.IsNullOrEmpty(userDesc) && !userDesc.StartsWith("AssignStep"))
+                friendlyName = userDesc;
+            else if (!string.IsNullOrEmpty(entityName))
+                friendlyName = "Assign " + entityName;
+
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.Assign,
+                Name = friendlyName,
+                StepId = ExtractStepIdFromDisplayName(node),
+                TargetEntity = entityName,
+                NestingLevel = nestingLevel
+            };
+
+            // Extract the Owner assignment
+            string owner = node.Attributes?["Owner"]?.Value;
+            if (!string.IsNullOrEmpty(owner))
+                step.Fields.Add(new ClassicWorkflowFieldAssignment { FieldName = "Assign To", Value = CleanDynamicExpression(owner), SourceType = owner.StartsWith("[") ? "Dynamic" : "Static" });
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParseClientActivity(XmlNode node, ClassicWorkflowStepType stepType, int nestingLevel)
+        {
+            var step = new ClassicWorkflowStep
+            {
+                StepType = stepType,
+                Name = ExtractDisplayNameDescription(node) ?? stepType.ToString(),
+                StepId = ExtractStepIdFromDisplayName(node),
+                TargetEntity = node.Attributes?["EntityName"]?.Value,
+                NestingLevel = nestingLevel
+            };
+
+            // Capture the control/field being modified
+            string controlId = node.Attributes?["ControlId"]?.Value;
+            if (!string.IsNullOrEmpty(controlId))
+            {
+                string detail = stepType switch
+                {
+                    ClassicWorkflowStepType.SetVisibility =>
+                        node.Attributes?["IsVisible"]?.Value,
+                    ClassicWorkflowStepType.SetDisplayMode =>
+                        node.Attributes?["IsReadOnly"]?.Value != null ? (node.Attributes["IsReadOnly"].Value == "True" ? "Read-Only" : "Editable") : null,
+                    ClassicWorkflowStepType.SetFieldRequired =>
+                        node.Attributes?["RequiredLevel"]?.Value,
+                    _ => null
+                };
+                step.Fields.Add(new ClassicWorkflowFieldAssignment
+                {
+                    FieldName = controlId,
+                    Value = detail ?? "",
+                    SourceType = "Static"
+                });
+            }
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParseConditionSequence(XmlNode node, int nestingLevel)
+        {
+            // Check if this is a Wait Condition (ConditionSequence with Wait=True)
+            bool isWait = false;
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference.Arguments")
+                {
+                    foreach (XmlNode arg in child.ChildNodes)
+                    {
+                        string argKey = arg.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(arg, "Key");
+                        if (argKey == "Wait" && arg.InnerText?.Trim() == "True")
+                        {
+                            isWait = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            var step = new ClassicWorkflowStep
+            {
+                StepType = isWait ? ClassicWorkflowStepType.Wait : ClassicWorkflowStepType.CheckCondition,
+                Name = ExtractDisplayNameDescription(node) ?? (isWait ? "Wait Condition" : "Check Condition"),
+                StepId = ExtractStepIdFromDisplayName(node),
+                NestingLevel = nestingLevel
+            };
+
+            // Parse child activities to find branches and nested steps
+            XmlNode activitiesCollection = FindActivitiesCollection(node);
+            if (activitiesCollection != null)
+            {
+                ParseStepsRecursive(activitiesCollection, step.ChildSteps, nestingLevel + 1);
+            }
+
+            // Relabel ConditionBranch children to match Dataverse editor: If / Otherwise If / Otherwise
+            bool firstConditionalBranch = true;
+            foreach (var child in step.ChildSteps)
+            {
+                if (child.StepType != ClassicWorkflowStepType.ConditionBranch) continue;
+
+                if (child.Name == "Otherwise (Default)")
+                {
+                    // Already labeled by ParseConditionBranch
+                    continue;
+                }
+
+                if (firstConditionalBranch)
+                {
+                    child.Name = "If";
+                    firstConditionalBranch = false;
+                }
+                else
+                {
+                    child.Name = "Otherwise If";
+                }
+            }
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParseConditionBranch(XmlNode node, int nestingLevel)
+        {
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.ConditionBranch,
+                Name = ExtractDisplayNameDescription(node) ?? "Condition Branch",
+                StepId = ExtractStepIdFromDisplayName(node),
+                NestingLevel = nestingLevel
+            };
+
+            // Resolve the condition expression tree from the Condition argument variable
+            string conditionRef = null;
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference.Arguments")
+                {
+                    foreach (XmlNode arg in child.ChildNodes)
+                    {
+                        string argKey = arg.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(arg, "Key");
+                        if (argKey == "Condition")
+                        {
+                            conditionRef = arg.InnerText?.Trim()?.Trim('[', ']');
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(conditionRef))
+            {
+                if (conditionRef == "True")
+                {
+                    step.ConditionDescription = "Otherwise (Default)";
+                    step.Name = "Otherwise (Default)";
+                }
+                else if (_conditionTreeMap != null && _conditionTreeMap.TryGetValue(conditionRef, out var tree))
+                {
+                    step.ConditionTree = tree;
+                    step.ConditionDescription = tree.ToFlatString();
+                }
+            }
+
+            // Parse the "Then" branch
+            XmlNode thenBranch = FindPropertyNode(node, "Then");
+            if (thenBranch != null)
+            {
+                ParseStepsRecursive(thenBranch, step.ChildSteps, nestingLevel + 1);
+            }
+
+            // Parse the "Else" branch
+            XmlNode elseBranch = FindPropertyNode(node, "Else");
+            if (elseBranch != null && elseBranch.LocalName != "Null")
+            {
+                ParseStepsRecursive(elseBranch, step.ChildSteps, nestingLevel + 1);
+            }
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep ParseComposite(XmlNode node, int nestingLevel)
+        {
+            string displayName = node.Attributes?["DisplayName"]?.Value;
+
+            // Composites wrapping custom activities — look for the inner custom ActivityReference
+            if (displayName != null && (displayName.StartsWith("CustomActivityStep") || displayName.StartsWith("InvokeSdkMessageStep")))
+            {
+                var customStep = FindNestedCustomActivity(node, nestingLevel);
+                if (customStep != null) return customStep;
+                // Also search for InvokeSdkMessageActivity directly
+                var actionStep = FindNestedInvokeSdkMessage(node, nestingLevel);
+                if (actionStep != null) return actionStep;
+            }
+
+            // Otherwise, generic composite — recurse into children to find real steps
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.Custom,
+                Name = ExtractDisplayNameDescription(node) ?? "Composite",
+                StepId = ExtractStepIdFromDisplayName(node),
+                NestingLevel = nestingLevel
+            };
+
+            XmlNode activitiesCollection = FindActivitiesCollection(node);
+            if (activitiesCollection != null)
+            {
+                ParseStepsRecursive(activitiesCollection, step.ChildSteps, nestingLevel + 1);
+            }
+
+            // If composite had no user-visible content, skip it
+            if (step.ChildSteps.Count == 0 && string.IsNullOrEmpty(step.Name))
+                return null;
+
+            return step;
+        }
+
+        private static ClassicWorkflowStep FindNestedCustomActivity(XmlNode compositeNode, int nestingLevel)
+        {
+            foreach (XmlNode child in compositeNode.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference")
+                {
+                    string aqn = child.Attributes?["AssemblyQualifiedName"]?.Value;
+                    if (!string.IsNullOrEmpty(aqn) &&
+                        !aqn.StartsWith("Microsoft.Crm.Workflow") &&
+                        !aqn.StartsWith("Microsoft.Xrm.Sdk"))
+                    {
+                        return ParseCustomActivity(child, aqn, nestingLevel);
+                    }
+                }
+
+                // Recurse through Properties/Activities collections
+                var found = FindNestedCustomActivity(child, nestingLevel);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        private static ClassicWorkflowStep FindNestedInvokeSdkMessage(XmlNode compositeNode, int nestingLevel)
+        {
+            foreach (XmlNode child in compositeNode.ChildNodes)
+            {
+                if (child.LocalName == "InvokeSdkMessageActivity")
+                {
+                    return TryParseAsStep(child, nestingLevel);
+                }
+
+                var found = FindNestedInvokeSdkMessage(child, nestingLevel);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        private static ClassicWorkflowStep ParseCustomActivity(XmlNode node, string aqn, int nestingLevel)
+        {
+            // AQN format: "MARCY.Activities.DateTimes.ToFormattedString, MARCY.Activities, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2fb77a038cccb985"
+            string[] aqnParts = aqn.Split(',');
+            string fullClassName = aqnParts[0].Trim();
+            string assemblyName = aqnParts.Length > 1 ? aqnParts[1].Trim() : "";
+
+            // Build a readable assembly description including version and public key token
+            string assemblyDesc = assemblyName;
+            for (int i = 2; i < aqnParts.Length; i++)
+            {
+                string part = aqnParts[i].Trim();
+                if (part.StartsWith("Version=") || part.StartsWith("PublicKeyToken="))
+                    assemblyDesc += ", " + part;
+            }
+
+            // Use the last segment of the full class name as a friendly name
+            int lastDot = fullClassName.LastIndexOf('.');
+            string shortName = lastDot >= 0 ? fullClassName.Substring(lastDot + 1) : fullClassName;
+
+            var step = new ClassicWorkflowStep
+            {
+                StepType = ClassicWorkflowStepType.Custom,
+                Name = ExtractDisplayNameDescription(node) ?? shortName,
+                StepId = ExtractStepIdFromDisplayName(node),
+                CustomActivityName = shortName,
+                CustomActivityClass = fullClassName,
+                CustomActivityAssembly = assemblyDesc,
+                NestingLevel = nestingLevel
+            };
+
+            // Extract input arguments as field assignments
+            ExtractCustomActivityArguments(node, step.Fields);
+
+            return step;
+        }
+
+        private static void ExtractCustomActivityArguments(XmlNode node, List<ClassicWorkflowFieldAssignment> fields)
+        {
+            // Find Arguments child
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference.Arguments")
+                {
+                    foreach (XmlNode argNode in child.ChildNodes)
+                    {
+                        // InArgument elements have x:Key for name
+                        string key = argNode.Attributes?["x:Key"]?.Value ??
+                                     GetAttributeByLocalName(argNode, "Key");
+                        if (!string.IsNullOrEmpty(key) &&
+                            argNode.LocalName != "OutArgument" &&
+                            key != "Result")
+                        {
+                            string rawValue = argNode.InnerText?.Trim() ?? "";
+                            string cleanValue = CleanDynamicExpression(rawValue);
+                            bool isDynamic = rawValue.StartsWith("[") && rawValue.EndsWith("]");
+
+                            fields.Add(new ClassicWorkflowFieldAssignment
+                            {
+                                FieldName = key,
+                                Value = cleanValue,
+                                SourceType = isDynamic ? "Dynamic" : "Static"
+                            });
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves raw XAML dynamic expressions into human-readable form using the variable map.
+        /// "[DirectCast(CustomActivityStep5_1_converted, System.String)]" → "{msf_reportingdate}" (resolved)
+        /// "[New Object() { ... }]" → literal or expression
+        /// Static values pass through unchanged.
+        /// </summary>
+        private static string CleanDynamicExpression(string raw)
+        {
+            if (string.IsNullOrEmpty(raw)) return raw;
+
+            // Not a dynamic expression — return as-is
+            if (!raw.StartsWith("[") || !raw.EndsWith("]"))
+                return raw;
+
+            string inner = raw.Substring(1, raw.Length - 2);
+
+            // DirectCast(varName, System.Type) → resolve via variable map
+            if (inner.StartsWith("DirectCast("))
+            {
+                // Extract variable name: DirectCast(CustomActivityStep5_1_converted, System.String)
+                int commaIdx = inner.LastIndexOf(',');
+                if (commaIdx >= 0)
+                {
+                    string varName = inner.Substring(11, commaIdx - 11).Trim(); // skip "DirectCast("
+                    if (_variableMap != null && _variableMap.TryGetValue(varName, out string resolved))
+                        return resolved;
+
+                    // Try without _converted suffix
+                    string baseVar = varName.Replace("_converted", "");
+                    if (_variableMap != null && _variableMap.TryGetValue(baseVar, out string resolvedBase))
+                        return resolvedBase;
+
+                    // Fallback: show the type
+                    string typePart = inner.Substring(commaIdx + 1).TrimEnd(')').Trim();
+                    int dotIdx = typePart.LastIndexOf('.');
+                    string shortType = dotIdx >= 0 ? typePart.Substring(dotIdx + 1) : typePart;
+                    return "(Dynamic " + shortType + ")";
+                }
+                return "(Dynamic)";
+            }
+
+            // Simple variable reference [VariableName] — resolve
+            if (!inner.Contains(' ') && !inner.Contains('('))
+            {
+                if (_variableMap != null && _variableMap.TryGetValue(inner, out string resolved))
+                    return resolved;
+            }
+
+            // New Object() { ... } → try to extract literal
+            if (inner.StartsWith("New "))
+            {
+                string literal = ExtractLiteralFromCreateCrmType(inner);
+                if (!string.IsNullOrEmpty(literal))
+                    return "\"" + literal + "\"";
+                return "(Expression)";
+            }
+
+            return "(Dynamic)";
+        }
+
+        // ── Field assignment collection ──
+
+        private static void CollectFieldAssignmentsFromSiblings(XmlNode stepNode, List<ClassicWorkflowFieldAssignment> fields)
+        {
+            // SetEntityProperty elements appear as siblings to UpdateEntity/CreateEntity
+            // within the same Sequence parent
+            XmlNode parent = stepNode.ParentNode;
+            if (parent == null) return;
+
+            string targetEntity = stepNode.Attributes?["EntityName"]?.Value;
+
+            foreach (XmlNode sibling in parent.ChildNodes)
+            {
+                if (sibling.LocalName == "SetEntityProperty")
+                {
+                    string attr = sibling.Attributes?["Attribute"]?.Value;
+                    string entityName = sibling.Attributes?["EntityName"]?.Value;
+
+                    if (!string.IsNullOrEmpty(attr) &&
+                        (string.IsNullOrEmpty(targetEntity) || string.IsNullOrEmpty(entityName) ||
+                         entityName.Equals(targetEntity, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        // Resolve the value from the variable map
+                        string valueRef = sibling.Attributes?["Value"]?.Value;
+                        string resolvedValue = "";
+                        string sourceType = "Dynamic";
+
+                        if (string.IsNullOrEmpty(valueRef))
+                        {
+                            resolvedValue = "(Clear)";
+                            sourceType = "Static";
+                        }
+                        else
+                        {
+                            string varName = valueRef.Trim('[', ']');
+                            if (_variableMap != null && _variableMap.TryGetValue(varName, out string mapped))
+                            {
+                                resolvedValue = mapped;
+                            }
+                            else
+                            {
+                                // Fallback: show the target type
+                                string targetType = ExtractTargetTypeName(sibling);
+                                resolvedValue = !string.IsNullOrEmpty(targetType) ? "(" + targetType + ")" : "(Dynamic)";
+                            }
+                        }
+
+                        fields.Add(new ClassicWorkflowFieldAssignment
+                        {
+                            FieldName = attr,
+                            Value = resolvedValue,
+                            SourceType = sourceType
+                        });
+                    }
+                }
+            }
+        }
+
+        // ── Helpers ──
+
+        private static string ExtractTypeName(string assemblyQualifiedName)
+        {
+            string fullType = assemblyQualifiedName.Split(',')[0].Trim();
+            int lastDot = fullType.LastIndexOf('.');
+            return lastDot >= 0 ? fullType.Substring(lastDot + 1) : fullType;
+        }
+
+        private static string ExtractDisplayNameDescription(XmlNode node)
+        {
+            string displayName = node.Attributes?["DisplayName"]?.Value;
+            if (string.IsNullOrEmpty(displayName)) return null;
+
+            // Pattern: "UpdateStep3: Update Change Request" → "Update Change Request"
+            int colonIndex = displayName.IndexOf(':');
+            if (colonIndex >= 0)
+            {
+                string desc = displayName.Substring(colonIndex + 1).Trim();
+                if (!string.IsNullOrEmpty(desc)) return desc;
+            }
+            return displayName;
+        }
+
+        private static string ExtractStepIdFromDisplayName(XmlNode node)
+        {
+            string displayName = node.Attributes?["DisplayName"]?.Value;
+            if (string.IsNullOrEmpty(displayName)) return null;
+
+            int colonIndex = displayName.IndexOf(':');
+            return colonIndex >= 0 ? displayName.Substring(0, colonIndex).Trim() : displayName;
+        }
+
+        /// <summary>
+        /// Extracts the user-provided step description from the parent Sequence's Variables.
+        /// Steps are wrapped in a Sequence element that contains Variables like:
+        ///   Variable Name="stepLabelDescription" Default="User's description text"
+        /// </summary>
+        private static string ExtractStepDescription(XmlNode stepNode)
+        {
+            // The step element (e.g., TerminateWorkflow, UpdateEntity) is inside a Sequence.
+            // Check the parent and grandparent for Sequence.Variables containing stepLabelDescription.
+            XmlNode sequenceNode = stepNode.ParentNode;
+            if (sequenceNode == null) return null;
+
+            // The parent might be the Sequence itself, or we might need to go up one more level
+            for (int depth = 0; depth < 2; depth++)
+            {
+                if (sequenceNode == null) break;
+                if (sequenceNode.LocalName == "Sequence")
+                {
+                    foreach (XmlNode child in sequenceNode.ChildNodes)
+                    {
+                        if (child.LocalName == "Sequence.Variables")
+                        {
+                            foreach (XmlNode variable in child.ChildNodes)
+                            {
+                                if (variable.LocalName == "Variable" &&
+                                    variable.Attributes?["Name"]?.Value == "stepLabelDescription")
+                                {
+                                    string desc = variable.Attributes?["Default"]?.Value;
+                                    if (!string.IsNullOrEmpty(desc))
+                                        return desc;
+                                }
+                            }
+                        }
+                    }
+                    return null; // Found Sequence but no description
+                }
+                sequenceNode = sequenceNode.ParentNode;
+            }
+            return null;
+        }
+
+        private static string ExtractOptionSetValue(XmlNode node, string propertyName)
+        {
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.LocalName == "SetState." + propertyName || child.LocalName.EndsWith("." + propertyName))
+                {
+                    return FindOptionSetValue(child);
+                }
+            }
+            return null;
+        }
+
+        private static string FindOptionSetValue(XmlNode node)
+        {
+            if (node == null) return null;
+            if (node.LocalName == "OptionSetValue")
+                return node.Attributes?["Value"]?.Value;
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                string result = FindOptionSetValue(child);
+                if (result != null) return result;
+            }
+            return null;
+        }
+
+        private static string ExtractTargetTypeName(XmlNode setEntityPropertyNode)
+        {
+            foreach (XmlNode child in setEntityPropertyNode.ChildNodes)
+            {
+                if (child.LocalName == "SetEntityProperty.TargetType" || child.LocalName.EndsWith(".TargetType"))
+                    return FindReferenceLiteralValue(child);
+            }
+            return null;
+        }
+
+        private static string FindReferenceLiteralValue(XmlNode node)
+        {
+            if (node == null) return null;
+            if (node.LocalName == "ReferenceLiteral")
+            {
+                string val = node.Attributes?["Value"]?.Value;
+                if (!string.IsNullOrEmpty(val))
+                {
+                    int colonIdx = val.IndexOf(':');
+                    return colonIdx >= 0 ? val.Substring(colonIdx + 1) : val;
+                }
+            }
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                string result = FindReferenceLiteralValue(child);
+                if (result != null) return result;
+            }
+            return null;
+        }
+
+        private static XmlNode FindActivitiesCollection(XmlNode activityRefNode)
+        {
+            foreach (XmlNode child in activityRefNode.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference.Properties")
+                {
+                    foreach (XmlNode prop in child.ChildNodes)
+                    {
+                        string key = prop.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(prop, "Key");
+                        if (key == "Activities")
+                            return prop;
+                    }
+                }
+                string directKey = child.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(child, "Key");
+                if (directKey == "Activities")
+                    return child;
+            }
+            return null;
+        }
+
+        private static XmlNode FindPropertyNode(XmlNode activityRefNode, string propertyKey)
+        {
+            foreach (XmlNode child in activityRefNode.ChildNodes)
+            {
+                if (child.LocalName == "ActivityReference.Properties")
+                {
+                    foreach (XmlNode prop in child.ChildNodes)
+                    {
+                        string key = prop.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(prop, "Key");
+                        if (key == propertyKey)
+                            return prop;
+                    }
+                }
+                string directKey = child.Attributes?["x:Key"]?.Value ?? GetAttributeByLocalName(child, "Key");
+                if (directKey == propertyKey)
+                    return child;
+            }
+            return null;
+        }
+
+        private static bool IsSkippableStructuralNode(XmlNode node)
+        {
+            string localName = node.LocalName;
+            return localName == "Variable" ||
+                   localName == "Members" ||
+                   localName == "Property" ||
+                   localName == "VisualBasic.Settings" ||
+                   localName == "Persist" ||
+                   localName == "GetEntityProperty" ||
+                   localName == "RetrieveEntity" ||
+                   localName == "SetEntityProperty";
+        }
+
+        private static string GetAttributeByLocalName(XmlNode node, string localName)
+        {
+            if (node.Attributes == null) return null;
+            foreach (XmlAttribute attr in node.Attributes)
+            {
+                if (attr.LocalName == localName)
+                    return attr.Value;
+            }
+            return null;
+        }
+
+        // ── Table reference building ──
+
+        private static void BuildTableReferences(ClassicWorkflowEntity workflow)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (!string.IsNullOrEmpty(workflow.PrimaryEntity))
+            {
+                string key = workflow.PrimaryEntity + "|Trigger";
+                if (seen.Add(key))
+                {
+                    workflow.TableReferences.Add(new ClassicWorkflowTableReference
+                    {
+                        TableLogicalName = workflow.PrimaryEntity,
+                        ReferenceType = ClassicWorkflowReferenceType.Trigger
+                    });
+                }
+            }
+
+            CollectTableReferencesFromSteps(workflow.Steps, workflow.TableReferences, seen);
+
+            // Extract related entity references from the variable map
+            // Variables like "{systemuser (Related).address1_composite}" indicate a Read on systemuser
+            if (_variableMap != null)
+            {
+                foreach (var entry in _variableMap.Values)
+                {
+                    if (string.IsNullOrEmpty(entry) || !entry.Contains("(Related)")) continue;
+
+                    // Pattern: {entityname (Related).fieldname} or just entityname (Related).fieldname
+                    string clean = entry.Trim('{', '}');
+                    int dotIdx = clean.IndexOf('.');
+                    if (dotIdx <= 0) continue;
+
+                    string entityPart = clean.Substring(0, dotIdx).Replace(" (Related)", "").Trim();
+                    if (string.IsNullOrEmpty(entityPart)) continue;
+
+                    string key = entityPart + "|Read";
+                    if (seen.Add(key))
+                    {
+                        workflow.TableReferences.Add(new ClassicWorkflowTableReference
+                        {
+                            TableLogicalName = entityPart,
+                            ReferenceType = ClassicWorkflowReferenceType.Read
+                        });
+                    }
+                }
+            }
+        }
+
+        private static void CollectTableReferencesFromSteps(List<ClassicWorkflowStep> steps,
+            List<ClassicWorkflowTableReference> references, HashSet<string> seen)
+        {
+            foreach (var step in steps)
+            {
+                if (!string.IsNullOrEmpty(step.TargetEntity))
+                {
+                    ClassicWorkflowReferenceType refType = step.StepType switch
+                    {
+                        ClassicWorkflowStepType.CreateRecord => ClassicWorkflowReferenceType.Create,
+                        ClassicWorkflowStepType.UpdateRecord => ClassicWorkflowReferenceType.Update,
+                        ClassicWorkflowStepType.Assign => ClassicWorkflowReferenceType.Assign,
+                        ClassicWorkflowStepType.ChangeStatus => ClassicWorkflowReferenceType.ChangeStatus,
+                        ClassicWorkflowStepType.SendEmail => ClassicWorkflowReferenceType.SendEmail,
+                        _ => ClassicWorkflowReferenceType.Read
+                    };
+
+                    string key = step.TargetEntity + "|" + refType;
+                    if (seen.Add(key))
+                    {
+                        references.Add(new ClassicWorkflowTableReference
+                        {
+                            TableLogicalName = step.TargetEntity,
+                            ReferenceType = refType
+                        });
+                    }
+                }
+
+                if (step.ChildSteps.Count > 0)
+                    CollectTableReferencesFromSteps(step.ChildSteps, references, seen);
+            }
+        }
+    }
+}

--- a/PowerDocu.Common/ConfigHelper.cs
+++ b/PowerDocu.Common/ConfigHelper.cs
@@ -19,6 +19,7 @@ namespace PowerDocu.Common
         public bool documentModelDrivenApps = true;
         public bool documentBusinessProcessFlows = true;
         public bool documentDesktopFlows = true;
+        public bool documentClassicWorkflows = true;
         public bool documentApps = true;
         public bool documentAppProperties = true;
         public bool documentAppVariables = true;
@@ -55,6 +56,7 @@ namespace PowerDocu.Common
                     documentModelDrivenApps = config.documentModelDrivenApps;
                     documentBusinessProcessFlows = config.documentBusinessProcessFlows;
                     documentDesktopFlows = config.documentDesktopFlows;
+                    documentClassicWorkflows = config.documentClassicWorkflows;
                     documentFlows = config.documentFlows;
                     documentApps = config.documentApps;
                     documentAppProperties = config.documentAppProperties;

--- a/PowerDocu.Common/CustomizationsEntity.cs
+++ b/PowerDocu.Common/CustomizationsEntity.cs
@@ -19,6 +19,7 @@ namespace PowerDocu.Common
         private List<WebResourceEntity> webResources;
         private List<RibbonCustomizationEntity> ribbonCustomizations;
         private List<DesktopFlowEntity> desktopFlows;
+        private List<ClassicWorkflowEntity> classicWorkflows;
         private List<DataflowEntity> dataflows;
 
         public string getAppNameBySchemaName(string schemaName)
@@ -247,6 +248,123 @@ namespace PowerDocu.Common
                 desktopFlows.Sort((a, b) => a.GetDisplayName().CompareTo(b.GetDisplayName()));
             }
             return desktopFlows;
+        }
+
+        public List<ClassicWorkflowEntity> getClassicWorkflows()
+        {
+            if (classicWorkflows == null)
+            {
+                classicWorkflows = new List<ClassicWorkflowEntity>();
+                foreach (XmlNode workflowNode in customizationsXml.SelectNodes("/ImportExportXml/Workflows/Workflow"))
+                {
+                    XmlNode categoryNode = workflowNode.SelectSingleNode("Category");
+                    // Category 0 = Classic Workflow (background/synchronous)
+                    if (categoryNode == null || categoryNode.InnerText != "0")
+                        continue;
+
+                    var workflow = new ClassicWorkflowEntity
+                    {
+                        ID = workflowNode.Attributes?.GetNamedItem("WorkflowId")?.InnerText?.Trim('{', '}'),
+                        Name = workflowNode.Attributes?.GetNamedItem("Name")?.InnerText,
+                        XamlFileName = workflowNode.SelectSingleNode("XamlFileName")?.InnerText,
+                        PrimaryEntity = workflowNode.SelectSingleNode("PrimaryEntity")?.InnerText,
+                        UniqueName = workflowNode.SelectSingleNode("UniqueName")?.InnerText
+                            ?? workflowNode.Attributes?.GetNamedItem("Name")?.InnerText,
+                        Category = int.TryParse(categoryNode.InnerText, out int cat) ? cat : 0,
+                        Mode = int.TryParse(workflowNode.SelectSingleNode("Mode")?.InnerText, out int mode) ? mode : 0,
+                        Scope = int.TryParse(workflowNode.SelectSingleNode("Scope")?.InnerText, out int scope) ? scope : 1,
+                        OnDemand = workflowNode.SelectSingleNode("OnDemand")?.InnerText == "1",
+                        TriggerOnCreate = workflowNode.SelectSingleNode("TriggerOnCreate")?.InnerText == "1",
+                        TriggerOnDelete = workflowNode.SelectSingleNode("TriggerOnDelete")?.InnerText == "1",
+                        TriggerOnUpdateAttributeList = workflowNode.SelectSingleNode("TriggerOnUpdateAttributeList")?.InnerText,
+                        StateCode = int.TryParse(workflowNode.SelectSingleNode("StateCode")?.InnerText, out int sc) ? sc : 0,
+                        StatusCode = int.TryParse(workflowNode.SelectSingleNode("StatusCode")?.InnerText, out int stc) ? stc : 0,
+                        IntroducedVersion = workflowNode.SelectSingleNode("IntroducedVersion")?.InnerText,
+                        IsCustomizable = workflowNode.SelectSingleNode("IsCustomizable")?.InnerText == "1",
+                        Rank = int.TryParse(workflowNode.SelectSingleNode("Rank")?.InnerText, out int rank) ? rank : 0,
+                        OwnerId = workflowNode.SelectSingleNode("OwnerId")?.InnerText
+                    };
+
+                    // Parse LocalizedNames
+                    XmlNode localizedNamesNode = workflowNode.SelectSingleNode("LocalizedNames");
+                    if (localizedNamesNode != null)
+                    {
+                        foreach (XmlNode ln in localizedNamesNode.ChildNodes)
+                        {
+                            if (ln.Name == "LocalizedName")
+                            {
+                                string langCode = ln.Attributes?.GetNamedItem("languagecode")?.InnerText;
+                                string desc = ln.Attributes?.GetNamedItem("description")?.InnerText;
+                                if (langCode != null && desc != null)
+                                    workflow.LocalizedNames[langCode] = desc;
+                            }
+                        }
+                    }
+
+                    // Parse Descriptions
+                    XmlNode descriptionsNode = workflowNode.SelectSingleNode("Descriptions");
+                    if (descriptionsNode != null)
+                    {
+                        foreach (XmlNode dn in descriptionsNode.ChildNodes)
+                        {
+                            if (dn.Name == "Description")
+                            {
+                                string langCode = dn.Attributes?.GetNamedItem("languagecode")?.InnerText;
+                                string desc = dn.Attributes?.GetNamedItem("description")?.InnerText;
+                                if (langCode != null && desc != null)
+                                    workflow.Descriptions[langCode] = desc;
+                            }
+                        }
+                    }
+
+                    if (workflow.Descriptions.ContainsKey("1033"))
+                        workflow.Description = workflow.Descriptions["1033"];
+                    else if (workflow.Descriptions.Count > 0)
+                        workflow.Description = new List<string>(workflow.Descriptions.Values)[0];
+
+                    classicWorkflows.Add(workflow);
+                }
+                classicWorkflows.Sort((a, b) => a.GetDisplayName().CompareTo(b.GetDisplayName()));
+            }
+            return classicWorkflows;
+        }
+
+        /// <summary>
+        /// Looks up custom workflow activity metadata (FriendlyName, Description, GroupName)
+        /// from the PluginAssemblies section of customizations.xml by the full type name.
+        /// </summary>
+        public (string FriendlyName, string Description, string GroupName) getWorkflowActivityMetadata(string fullTypeName)
+        {
+            if (string.IsNullOrEmpty(fullTypeName)) return (null, null, null);
+
+            // Search: /ImportExportXml/SolutionPluginAssemblies/PluginAssembly/PluginTypes/PluginType
+            // Also try: /ImportExportXml/PluginAssemblies/PluginAssembly/PluginTypes/PluginType
+            string[] xpaths = new[]
+            {
+                "/ImportExportXml/SolutionPluginAssemblies/PluginAssembly/PluginTypes/PluginType",
+                "/ImportExportXml/PluginAssemblies/PluginAssembly/PluginTypes/PluginType"
+            };
+
+            foreach (string xpath in xpaths)
+            {
+                XmlNodeList pluginTypes = customizationsXml.SelectNodes(xpath);
+                if (pluginTypes == null) continue;
+
+                foreach (XmlNode pt in pluginTypes)
+                {
+                    string typeName = pt.SelectSingleNode("TypeName")?.InnerText;
+                    if (typeName != null && typeName.Equals(fullTypeName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (
+                            pt.SelectSingleNode("FriendlyName")?.InnerText,
+                            pt.SelectSingleNode("Description")?.InnerText,
+                            pt.SelectSingleNode("WorkflowActivityGroupName")?.InnerText
+                        );
+                    }
+                }
+            }
+
+            return (null, null, null);
         }
 
         public List<DataflowEntity> getDataflows()

--- a/PowerDocu.Common/DocumentationContext.cs
+++ b/PowerDocu.Common/DocumentationContext.cs
@@ -18,6 +18,7 @@ namespace PowerDocu.Common
         public List<AppModuleEntity> AppModules { get; set; } = new List<AppModuleEntity>();
         public List<BPFEntity> BusinessProcessFlows { get; set; } = new List<BPFEntity>();
         public List<DesktopFlowEntity> DesktopFlows { get; set; } = new List<DesktopFlowEntity>();
+        public List<ClassicWorkflowEntity> ClassicWorkflows { get; set; } = new List<ClassicWorkflowEntity>();
         public List<DataflowEntity> Dataflows { get; set; } = new List<DataflowEntity>();
         public List<TableEntity> Tables { get; set; } = new List<TableEntity>();
         public List<RoleEntity> Roles { get; set; } = new List<RoleEntity>();

--- a/PowerDocu.Common/TableEntity.cs
+++ b/PowerDocu.Common/TableEntity.cs
@@ -273,6 +273,38 @@ namespace PowerDocu.Common
         {
             return xmlColumn.SelectSingleNode("IsFilterable")?.InnerText.Equals("1") ?? false;
         }
+
+        /// <summary>
+        /// Gets the display label for an option set value on this column.
+        /// Searches the column's optionset/options for a matching value.
+        /// </summary>
+        public string GetOptionSetLabel(string intValue)
+        {
+            if (string.IsNullOrEmpty(intValue)) return null;
+            XmlNodeList options = xmlColumn.SelectNodes("optionset/options/option");
+            if (options == null) return null;
+            foreach (XmlNode option in options)
+            {
+                string val = option.Attributes?.GetNamedItem("value")?.InnerText;
+                if (val == intValue)
+                {
+                    // Try English label first (1033)
+                    XmlNode labels = option.SelectSingleNode("labels");
+                    if (labels != null)
+                    {
+                        foreach (XmlNode label in labels.ChildNodes)
+                        {
+                            if (label.Attributes?.GetNamedItem("languagecode")?.InnerText == "1033")
+                                return label.Attributes?.GetNamedItem("description")?.InnerText;
+                        }
+                        // Fallback to first label
+                        XmlNode firstLabel = labels.FirstChild;
+                        return firstLabel?.Attributes?.GetNamedItem("description")?.InnerText;
+                    }
+                }
+            }
+            return null;
+        }
     }
 
     public class FormEntity


### PR DESCRIPTION
This pull request introduces support for classic workflows in the codebase, including their extraction, representation, and configuration. It also adds utility methods for option set label retrieval, improves the normalization of safe names, and exposes several new properties and methods for working with workflows and their metadata.  After this PR is merged I add another PR to the PowerDocu project to enable this in the UI.

**Classic Workflow Support**

* Added the `ClassicWorkflowEntity` class and related types (`ClassicWorkflowStep`, `ClassicWorkflowFieldAssignment`, `ClassicWorkflowTableReference`, `ConditionExpression`, etc.) to model classic workflows, their steps, fields, references, and conditions. (`PowerDocu.Common/ClassicWorkflowEntity.cs`)
* Implemented parsing and retrieval of classic workflows from the XML customizations file via the new `getClassicWorkflows()` method and storage in the `classicWorkflows` field. Also added a helper to retrieve workflow activity metadata. (`PowerDocu.Common/CustomizationsEntity.cs`) [[1]](diffhunk://#diff-56b86c9b4358afb89eef7c39c93982b5f100b41f4ffde2acebc3172600d0334aR22) [[2]](diffhunk://#diff-56b86c9b4358afb89eef7c39c93982b5f100b41f4ffde2acebc3172600d0334aR253-R369)
* Exposed classic workflows in the documentation context through the new `ClassicWorkflows` property. (`PowerDocu.Common/DocumentationContext.cs`)
* Added a configuration flag (`documentClassicWorkflows`) to enable or disable classic workflow documentation, including loading this flag from configuration files. (`PowerDocu.Common/ConfigHelper.cs`) [[1]](diffhunk://#diff-4997c40fac8683570f1c89467dd16f4d677aa2df54ce9fdb0b8fc71dd79c5abfR22) [[2]](diffhunk://#diff-4997c40fac8683570f1c89467dd16f4d677aa2df54ce9fdb0b8fc71dd79c5abfR59)

**Utility Improvements**

* Added `GetOptionSetLabel(string intValue)` to `TableEntity` for retrieving localized option set labels by value, prioritizing English (1033) and providing fallbacks. (`PowerDocu.Common/TableEntity.cs`)
* Improved the `GetSafeName` method to collapse consecutive dashes and trim leading/trailing dashes, ensuring cleaner normalized names. (`PowerDocu.Common/CharsetHelper.cs`)